### PR TITLE
fix(images): prevent theme color filters from affecting GitHub projec…

### DIFF
--- a/src/js/themeToggle.js
+++ b/src/js/themeToggle.js
@@ -14,7 +14,14 @@ function updateSvgColors(theme) {
     
     svgImages.forEach(img => {
         const src = img.src || img.getAttribute('src') || '';
-        if (src.toLowerCase().includes('project-images')) {
+        const srcLower = src.toLowerCase();
+        
+        if (srcLower.includes('preview.svg')) {
+            img.style.filter = '';
+            return;
+        }
+        
+        if (srcLower.includes('project-images')) {
             return;
         }
         


### PR DESCRIPTION
…t images

- Removed CSS filters that were incorrectly affecting project images

Related to: theme filter issues, image color preservation, GitHub projects display